### PR TITLE
feat: error message now red instead of green

### DIFF
--- a/githooks/branch_validate.sh
+++ b/githooks/branch_validate.sh
@@ -1,15 +1,18 @@
-#!/usr/bin/env bash
+#!/bin/sh -e
 LC_ALL=C
+
+NOCOLOR="\033[0m"
+RED="\033[0;31m"
 
 local_branch="$(git rev-parse --abbrev-ref HEAD)"
 
 valid_branch_regex="^(bug|chore|devops|feat|fix|hotfix|release)\/[a-zA-Z0-9._-]+$"
 
-message="Commit failed. Branch names in this project must adhere to this contract: $valid_branch_regex. Please rename your branch and try again."
+message="Commit failed. Branch names in this project must follow this pattern: $valid_branch_regex. Please rename your branch and try again."
 
 if [[ ! $local_branch =~ $valid_branch_regex ]]
 then
-    echo "$message"
+    echo ${RED}$message${NOCOLOR}
     exit 1
 fi
 


### PR DESCRIPTION
<!--

Note: Remember to add the 'in progress' label, if this PR is still a work-in-progress and create a draft PR. Once it's ready, please remove the label and mark the PR as ready for review!
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

Color output reference: [SO thread](https://stackoverflow.com/questions/5947742/how-to-change-the-output-color-of-echo-in-linux/28938235#28938235)


## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Edited colors for the script. When the message pops up, it now shows as red.

## Example:

![Screen Shot 2022-08-03 at 11 33 07 PM](https://user-images.githubusercontent.com/60058291/182761407-2195d768-c827-466a-a7bb-177ff7d6f559.png)


## Related Issues

Closes #2 